### PR TITLE
Prevent future bug with register_cmap

### DIFF
--- a/hciplot/hciplot.py
+++ b/hciplot/hciplot.py
@@ -14,6 +14,7 @@ from matplotlib.pyplot import colorbar as plt_colorbar
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 from matplotlib.cm import register_cmap
 import matplotlib.colors as colors
+from matplotlib.colors import LinearSegmentedColormap
 import matplotlib.cm as mplcm
 import warnings
 warnings.filterwarnings("ignore", module="matplotlib")
@@ -26,8 +27,8 @@ ds9cool = {'red': lambda v: 2 * v - 1,
 ds9heat = {'red': lambda v: np.interp(v, [0, 0.34, 1], [0, 1, 1]),
            'green': lambda v: np.interp(v, [0, 1], [0, 1]),
            'blue': lambda v: np.interp(v, [0, 0.65, 0.98, 1], [0, 0, 1, 1])}
-register_cmap('ds9cool', data=ds9cool)
-register_cmap('ds9heat', data=ds9heat)
+register_cmap(cmap=LinearSegmentedColormap('ds9cool', ds9cool))
+register_cmap(cmap=LinearSegmentedColormap('ds9heat', ds9heat))
 cmap_binary = colors.ListedColormap(['black', 'white'])
 default_cmap = 'viridis'
 


### PR DESCRIPTION
Based on current warning for: 
>register_cmap('ds9cool', data=ds9cool)
MatplotlibDeprecationWarning: Passing raw data via parameters data and lut to register_cmap() is deprecated since 3.3 and will become an error two minor releases later. Instead use: register_cmap(cmap=LinearSegmentedColormap(name, data, lut))